### PR TITLE
If the file is unsafe, the response code should be 200 instead of 410

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -9,7 +9,7 @@ class DocumentsController < ApplicationController
 
     if document.nil?
       render status: :not_found
-    elsif document && !document.document_file.file && %w[safe unsafe].any?{|state| state.include?(document.state.to_s) }
+    elsif document && !document.document_file.file && document.state == 'safe'
       render json: document.to_json, status: :gone
     else
       render json: document.to_json, status: :ok

--- a/spec/requests/documents_request_spec.rb
+++ b/spec/requests/documents_request_spec.rb
@@ -76,8 +76,8 @@ RSpec.describe "Documents", type: :request do
           get "/documents/#{document.id}", headers: headers
         end
 
-        it 'returns status code 410' do
-          expect(response).to have_http_status(410)
+        it 'returns status code 200' do
+          expect(response).to have_http_status(200)
         end
 
         it 'returns the Document record' do


### PR DESCRIPTION
Fix for when the state of the Document is 'unsafe': the response should be 200 instead of 410